### PR TITLE
corrected if comparison for networkId for testnet

### DIFF
--- a/cardanoLeaderLogs.js
+++ b/cardanoLeaderLogs.js
@@ -47,7 +47,7 @@ async function loadLedgerState(magicString) {
 
 async function calculateLeaderLogs() {
 
-  const magicString           = genesisShelley.networkId === 'testnet' ?
+  const magicString           = genesisShelley.networkId === 'Testnet' ?
     '--testnet-magic ' + genesisShelley.networkMagic :
     '--mainnet'
 


### PR DESCRIPTION
Corrected if comparison for networkId. For Cardano testnet the Id is "Testnet" instead of lower-case "testnet"