### PR TITLE
Add Libsodium installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,18 @@ pip3 --version
 pip3 install pytz
 ```
 
+### Libsodium
+
+```
+git clone https://github.com/input-output-hk/libsodium
+cd libsodium
+git checkout 66f017f1
+./autogen.sh
+./configure
+make
+sudo make install
+```
+
 ### cardano-node
 
 The node does not need to run as a block producer.


### PR DESCRIPTION
Hello! Thanks for the great tool you have developed.

I think the Libsodium installation instructions could be simplified but showing them as a block of code that installs the IOHK version - taken from the official docs (https://docs.cardano.org/projects/cardano-node/en/latest/getting-started/install.html#install-libsodium)